### PR TITLE
SLE 15.4 machines try to enable removed Python2 module

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,23 +31,6 @@ uyuni_packages:
 uyuni_suma_release: 4.3
 uyuni_scc_check_registration: true
 uyuni_scc_check_modules: true
-# The 'Desktop Applications' and 'Development Tools'
-# modules are required for CEFS!
-uyuni_sles_modules:
-  - name: sle-module-basesystem
-    identifier: "sle-module-basesystem/{{ ansible_distribution_version }}/{{ ansible_architecture }}"
-  - name: sle-module-python2
-    identifier: "sle-module-python2/{{ ansible_distribution_version }}/{{ ansible_architecture }}"
-  - name: sle-module-server-applications
-    identifier: "sle-module-server-applications/{{ ansible_distribution_version }}/{{ ansible_architecture }}"
-  - name: sle-module-web-scripting
-    identifier: "sle-module-web-scripting/{{ ansible_distribution_version }}/{{ ansible_architecture }}"
-  - name: sle-module-desktop-applications
-    identifier: "sle-module-desktop-applications/{{ ansible_distribution_version }}/{{ ansible_architecture }}"
-  - name: sle-module-development-tools
-    identifier: "sle-module-development-tools/{{ ansible_distribution_version }}/{{ ansible_architecture }}"
-  - name: sle-module-suse-manager-server
-    identifier: "sle-module-suse-manager-server/{{ uyuni_suma_release }}/{{ ansible_architecture }}"
 
 # storage configuration
 uyuni_use_lvm: true

--- a/molecule/README.md
+++ b/molecule/README.md
@@ -45,13 +45,15 @@ You might want to have a look at these sites in order to find out how to create 
 - [https://github.com/lavabit/robox](https://github.com/lavabit/robox)
 - [https://github.com/chef/bento/tree/master/packer_templates/sles](https://github.com/chef/bento/tree/master/packer_templates/sles)
 
-Beginning with SLE 15 SP2, SUSE ships Vagrantboxes again. To import it, use the following command:
+For SLE 15 SP2 and SP3, SUSE shiped Vagrantboxes again. To import it, use the following command:
 
 ```shell
 $ vagrant box add sles15-sp3 SLES15-SP3-Vagrant.x86_64-15.2-<provider>-*.vagrant.<provider>.box
 ```
 
 Replace `<provider>` with `virtualbox` or `libvirt`.
+
+In SLE 15 SP4, Vagrantboxes were removed, again. See [the following blog post](https://cstan.io/post/2023/02/sles-15-sp4-vagrantbox/) to see how to update an existing SP3 Vagrantbox.
 
 ## Usage
 

--- a/molecule/suma/molecule.yml
+++ b/molecule/suma/molecule.yml
@@ -9,7 +9,7 @@ lint: |
     flake8
 platforms:
   - name: suma4
-    box: sles15-sp3
+    box: sles15-sp4
     cpus: 2
     memory: 8192
 provisioner:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,14 @@
 ---
 - name: Include variables
-  ansible.builtin.include_vars: "{{ ansible_distribution | regex_replace(' ', '_') | lower }}.yml"
+  ansible.builtin.include_vars: "{{ lookup('ansible.builtin.first_found', params) }}"
+  vars:
+    params:
+      files:
+        - "{{ ansible_distribution | regex_replace(' ', '_') | lower }}-{{ ansible_distribution_version }}.yml"
+        - "{{ ansible_distribution | regex_replace(' ', '_') | lower }}.yml"
+        - main.yml
+      paths:
+        - 'vars'
 
 - name: Include check tasks
   ansible.builtin.include_tasks: "check_{{ ansible_distribution | regex_replace(' ', '_') | lower }}.yml"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-# vars file for ansible-uyuni
+# vars file for stdevel.uyuni

--- a/vars/sles-15.4.yml
+++ b/vars/sles-15.4.yml
@@ -7,8 +7,8 @@ uyuni_pattern:
 uyuni_sles_modules:
   - name: sle-module-basesystem
     identifier: "sle-module-basesystem/{{ ansible_distribution_version }}/{{ ansible_architecture }}"
-  - name: sle-module-python2
-    identifier: "sle-module-python2/{{ ansible_distribution_version }}/{{ ansible_architecture }}"
+  - name: sle-module-python3
+    identifier: "sle-module-python3/{{ ansible_distribution_version }}/{{ ansible_architecture }}"
   - name: sle-module-server-applications
     identifier: "sle-module-server-applications/{{ ansible_distribution_version }}/{{ ansible_architecture }}"
   - name: sle-module-web-scripting


### PR DESCRIPTION
Product requirements differ depending on the SUMA release (4.2 = SLE 15.3, still has Python2 module; 4.3 = SLE 15.4, no Python2 module available).

See also issue #45.